### PR TITLE
Integrate flyway for db migration

### DIFF
--- a/axelor-core/build.gradle
+++ b/axelor-core/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 		exclude group: "net.sf.ehcache"
 	}
 	compile libs.ehcache
+	compile libs.flywaydb
 
 	compile libs.jersey_server
 	compile libs.jersey_guice

--- a/axelor-core/src/test/java/com/axelor/db/MigrationTest.java
+++ b/axelor-core/src/test/java/com/axelor/db/MigrationTest.java
@@ -1,0 +1,30 @@
+/**
+ * Axelor Business Solutions
+ *
+ * Copyright (C) 2005-2015 Axelor (<http://axelor.com>).
+ *
+ * This program is free software: you can redistribute it and/or  modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.axelor.db;
+
+import org.junit.Test;
+
+import com.axelor.db.internal.DBHelper;
+
+public class MigrationTest {
+
+	@Test
+	public void test() {
+		DBHelper.migrate();
+	}
+}

--- a/axelor-core/src/test/resources/db/migration/V1__initialize.sql
+++ b/axelor-core/src/test/resources/db/migration/V1__initialize.sql
@@ -1,0 +1,4 @@
+create table foo (
+	code varchar(255) not null,
+	name varchar(255) not null
+)

--- a/axelor-core/src/test/resources/db/migration/V2__alter.sql
+++ b/axelor-core/src/test/resources/db/migration/V2__alter.sql
@@ -1,0 +1,1 @@
+alter table foo add column notes varchar(255);

--- a/axelor-gradle/src/init.d/02-libs.gradle
+++ b/axelor-gradle/src/init.d/02-libs.gradle
@@ -42,6 +42,9 @@ def libs = [
 	hibernate_ehcache: 	"org.hibernate:hibernate-ehcache:4.2.8.Final",
 	ehcache:		   	"net.sf.ehcache:ehcache:2.8.1",
 
+	// flyway
+	flywaydb:			"org.flywaydb:flyway-core:3.2.1",
+
 	// eclipselink
 	eclipselink_moxy:	"org.eclipse.persistence:org.eclipse.persistence.moxy:2.5.2",
 

--- a/axelor-gradle/src/main/groovy/com/axelor/gradle/AppPlugin.groovy
+++ b/axelor-gradle/src/main/groovy/com/axelor/gradle/AppPlugin.groovy
@@ -148,6 +148,16 @@ class AppPlugin extends AbstractPlugin {
 				jvmArgs "-Daxelor.config=" + System.getProperty('axelor.config')
 			}
 
+			task("migrate", dependsOn: "classes", type: JavaExec) {
+				description "Run database migration scripts."
+				group "Axelor"
+				main = "com.axelor.app.internal.AppInitCli"
+				classpath = sourceSets.main.runtimeClasspath
+				args "-M"
+				if (project.properties.verbose) args "--verbose"
+				jvmArgs "-Daxelor.config=" + System.getProperty('axelor.config')
+			}
+
 			compileJava.dependsOn "generateCode"
 
 			war.dependsOn "copyWebapp"

--- a/axelor-shell/src/main/java/com/axelor/shell/commands/GradleCommands.java
+++ b/axelor-shell/src/main/java/com/axelor/shell/commands/GradleCommands.java
@@ -106,6 +106,8 @@ public class GradleCommands implements CommandProvider {
 			launcher.withArguments(arguments.toArray(new String[] {}));
 			// Run the build
 			launcher.run();
+		} catch (Exception e) {
+			System.err.println("Command failed: " + e);
 		} finally {
 			connection.close();
 		}
@@ -183,6 +185,19 @@ public class GradleCommands implements CommandProvider {
 		}
 		if (modules != null && modules.length > 0) {
 			args.add("-Pmodules=" + Joiner.on(",").join(modules));
+		}
+		return execute(args.toArray(new String[] {}));
+	}
+
+	@CliCommand(name = "migrate", usage = "[OPTIONS]", help = "run database migration scripts")
+	public CommandResult migrate(
+			@CliOption(name = "config", shortName = 'c', argName = "FILE", help = "application configuration file", required = true)
+			String config,
+			@CliOption(name = "verbose", shortName = 'v', help = "verbose output")
+			boolean verbose) {
+		final List<String> args = Lists.newArrayList("-q", "-x", "test", "migrate", "-Daxelor.config=" + config);
+		if (verbose) {
+			args.add("-Pverbose=true");
 		}
 		return execute(args.toArray(new String[] {}));
 	}


### PR DESCRIPTION
Supported with shell command `migrate`. The scripts
should be included per application. No scripts are
provided from adk.